### PR TITLE
Fixed the azure mobile recipe create <name> command

### DIFF
--- a/azuremobile-recipe/recipeInit.js
+++ b/azuremobile-recipe/recipeInit.js
@@ -87,7 +87,7 @@ module.exports.init = function (cli) {
                     function (callback) {
                         azureRecipe = 'azuremobile-' + recipename;
                         // check if recipe exists in npm directory
-                        var progress = cli.progress('Checking recipe name availability');
+                        var progress = cli.interaction.progress('Checking recipe name availability');
                         recipe.exec('npm owner ls ' + azureRecipe, function (error, stdout, stderr) {
                             if (!error) {
                                 throw new Error('Recipe name ' + azureRecipe + ' already exists in npm directory');
@@ -183,7 +183,7 @@ module.exports.init = function (cli) {
                     function (callback) {
                         // error check: service exists
                         log.info('');
-                        var progress = cli.progress('Validating mobile service: \'' + servicename + '\'');
+                        var progress = cli.interaction.progress('Validating mobile service: \'' + servicename + '\'');
                         recipe.scripty.invoke('mobile show ' + servicename, function (err, results) {
                             progress.end();
                             if (err) return callback(err);

--- a/azuremobile-recipe/recipeInit.js
+++ b/azuremobile-recipe/recipeInit.js
@@ -98,7 +98,7 @@ module.exports.init = function (cli) {
                                         log.warn('Fail to delete npm-debug.log');
                                 });
                             }
-                            progress.end();                            
+                            progress.end();
                             callback();
                         });
                     },

--- a/azuremobile-recipe/recipeUtils.js
+++ b/azuremobile-recipe/recipeUtils.js
@@ -364,7 +364,9 @@ exports.makeDir = function (path, mode, callback) {
         parts,
         function (file, done) {
             file = parts.slice(0, parts.indexOf(file) + 1).join('/');
-
+            if (file === "")
+                file = '/';
+            
             exports.fs.stat(file, function (err, stat) {
                 if ((!err) && (stat) && (stat.isDirectory()))
                     done();


### PR DESCRIPTION
The current version of AMS recipe CLI module was not properly scaffolding new projects with the command:

azure mobile recipe create <recipe name>.

Changes to the Azure CLI seem to have made this fall out of sync. A small change to both the recipeInit.js file and the recipeUtils.js file corrected the problem.
